### PR TITLE
:green_heart: Removes redundant trigger in gh release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: release
 on:
   push:
-    branches:
-      - main
     tags:
       - "v*.*.*"
   pull_request:


### PR DESCRIPTION
Removes the release action branch 'main' trigger as it is not required.