### PR TITLE
fix: ensure that branches are sorted

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eu
+set -x
 
 # Apply hotfix for 'fatal: unsafe repository' error (see #9)
 git config --global --add safe.directory "${GITHUB_WORKSPACE}"
@@ -22,6 +23,7 @@ fi
 
 # Check if reference exists
 regex="(remotes/.*/)*${INPUT_REFERENCE}$"
+git branch -a --sort=refname
 if [[ "$(git branch -a --sort=refname | grep -Eow $regex | wc -l)" -ne 0 ]]; then
   input_type="branch"
   INPUT_REFERENCE="$(git branch -a --sort=refname | grep -Ewom 1 $regex)" # Replace with full branch name

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eu
-set -x
 
 # Apply hotfix for 'fatal: unsafe repository' error (see #9)
 git config --global --add safe.directory "${GITHUB_WORKSPACE}"
@@ -23,10 +22,9 @@ fi
 
 # Check if reference exists
 regex="(remotes/.*/)*${INPUT_REFERENCE}$"
-git branch -a --sort=refname
-if [[ "$(git branch -a --sort=refname | grep -Eow $regex | wc -l)" -ne 0 ]]; then
+if [[ "$(git branch -a --sort=refname | grep -v "\->" | grep -Eow $regex | wc -l)" -ne 0 ]]; then
   input_type="branch"
-  INPUT_REFERENCE="$(git branch -a --sort=refname | grep -Ewom 1 $regex)" # Replace with full branch name
+  INPUT_REFERENCE="$(git branch -a --sort=refname | grep -v "\->" | grep -Ewom 1 $regex)" # Replace with full branch name
 else
   if git cat-file -e "${INPUT_REFERENCE}"^{commit} 2>/dev/null &&
     [[ "${INPUT_REFERENCE}" != 'refs/tags/'* ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,9 +22,9 @@ fi
 
 # Check if reference exists
 regex="(remotes/.*/)*${INPUT_REFERENCE}$"
-if [[ "$(git branch -a | grep -Eow $regex | wc -l)" -ne 0 ]]; then
+if [[ "$(git branch -a --sort=refname | grep -Eow $regex | wc -l)" -ne 0 ]]; then
   input_type="branch"
-  INPUT_REFERENCE="$(git branch -a | grep -Ewom 1 $regex)" # Replace with full branch name
+  INPUT_REFERENCE="$(git branch -a --sort=refname | grep -Ewom 1 $regex)" # Replace with full branch name
 else
   if git cat-file -e "${INPUT_REFERENCE}"^{commit} 2>/dev/null &&
     [[ "${INPUT_REFERENCE}" != 'refs/tags/'* ]]; then


### PR DESCRIPTION
In some cases I have seen:

```console
[action-contains-tag] Branch 'remotes/origin/HEAD -> origin/main' does not contain tag '1.4.2'.
```

We see that the branch is incorrect (it should be `main`).  See log from my repo below, as well as this PRs own action (first and second commit [here](https://github.com/rickstaa/action-contains-tag/actions/runs/12939106173))

<details>

<summary>example log</summary>

```
2025-01-23T22:10:12.8583927Z Current runner version: '2.321.0'
2025-01-23T22:10:12.8609714Z ##[group]Operating System
2025-01-23T22:10:12.8610497Z Ubuntu
2025-01-23T22:10:12.8611147Z 24.04.1
2025-01-23T22:10:12.8611865Z LTS
2025-01-23T22:10:12.8612700Z ##[endgroup]
2025-01-23T22:10:12.8613275Z ##[group]Runner Image
2025-01-23T22:10:12.8613915Z Image: ubuntu-24.04
2025-01-23T22:10:12.8614444Z Version: 20250120.5.0
2025-01-23T22:10:12.8615498Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250120.5/images/ubuntu/Ubuntu2404-Readme.md
2025-01-23T22:10:12.8616957Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250120.5
2025-01-23T22:10:12.8617895Z ##[endgroup]
2025-01-23T22:10:12.8618430Z ##[group]Runner Image Provisioner
2025-01-23T22:10:12.8619065Z 2.0.417.1
2025-01-23T22:10:12.8619544Z ##[endgroup]
2025-01-23T22:10:12.8621884Z ##[group]GITHUB_TOKEN Permissions
2025-01-23T22:10:12.8624206Z Actions: write
2025-01-23T22:10:12.8625005Z Attestations: write
2025-01-23T22:10:12.8625637Z Checks: write
2025-01-23T22:10:12.8626245Z Contents: write
2025-01-23T22:10:12.8626765Z Deployments: write
2025-01-23T22:10:12.8627302Z Discussions: write
2025-01-23T22:10:12.8627820Z Issues: write
2025-01-23T22:10:12.8628384Z Metadata: read
2025-01-23T22:10:12.8628913Z Packages: write
2025-01-23T22:10:12.8629418Z Pages: write
2025-01-23T22:10:12.8629965Z PullRequests: write
2025-01-23T22:10:12.8630500Z RepositoryProjects: write
2025-01-23T22:10:12.8631077Z SecurityEvents: write
2025-01-23T22:10:12.8631657Z Statuses: write
2025-01-23T22:10:12.8632316Z ##[endgroup]
2025-01-23T22:10:12.8635508Z Secret source: Actions
2025-01-23T22:10:12.8636567Z Prepare workflow directory
2025-01-23T22:10:12.9008078Z Prepare all required actions
2025-01-23T22:10:12.9044491Z Getting action download info
2025-01-23T22:10:13.0635042Z Download action repository 'actions/checkout@v4' (SHA:11bd71901bbe5b1630ceea73d27597364c9af683)
2025-01-23T22:10:13.1570772Z Download action repository 'rickstaa/action-contains-tag@v1' (SHA:a9ff27d505ba2bf074a2ebb48b208e76d35ff308)
2025-01-23T22:10:13.5130075Z Complete job name: on-main-branch-check
2025-01-23T22:10:13.5595401Z ##[group]Build container for action use: '/home/runner/work/_actions/rickstaa/action-contains-tag/v1/Dockerfile'.
2025-01-23T22:10:13.5635878Z ##[command]/usr/bin/docker build -t 88fc44:57da35312ff946c2a167c21830a41d1c -f "/home/runner/work/_actions/rickstaa/action-contains-tag/v1/Dockerfile" "/home/runner/work/_actions/rickstaa/action-contains-tag/v1"
2025-01-23T22:10:14.0694021Z #0 building with "default" instance using docker driver
2025-01-23T22:10:14.0695335Z 
2025-01-23T22:10:14.0695767Z #1 [internal] load build definition from Dockerfile
2025-01-23T22:10:14.0696854Z #1 transferring dockerfile: 221B done
2025-01-23T22:10:14.0697638Z #1 DONE 0.0s
2025-01-23T22:10:14.0697930Z 
2025-01-23T22:10:14.0698383Z #2 [auth] library/alpine:pull token for registry-1.docker.io
2025-01-23T22:10:14.2186876Z #2 DONE 0.0s
2025-01-23T22:10:14.2187497Z 
2025-01-23T22:10:14.2188103Z #3 [internal] load metadata for docker.io/library/alpine:3.19
2025-01-23T22:10:14.4160471Z #3 DONE 0.4s
2025-01-23T22:10:14.5322460Z 
2025-01-23T22:10:14.5323366Z #4 [internal] load .dockerignore
2025-01-23T22:10:14.5324926Z #4 transferring context: 2B done
2025-01-23T22:10:14.5326308Z #4 DONE 0.0s
2025-01-23T22:10:14.5326987Z 
2025-01-23T22:10:14.5327379Z #5 [internal] load build context
2025-01-23T22:10:14.5328871Z #5 transferring context: 2.87kB done
2025-01-23T22:10:14.5330270Z #5 DONE 0.0s
2025-01-23T22:10:14.5330923Z 
2025-01-23T22:10:14.5332765Z #6 [1/6] FROM docker.io/library/alpine:3.19@sha256:6380aa6b04faa579332d4c9d1f65bd7093012ba6e01d9bbcd5e2d8a4f9fae38f
2025-01-23T22:10:14.5336282Z #6 resolve docker.io/library/alpine:3.19@sha256:6380aa6b04faa579332d4c9d1f65bd7093012ba6e01d9bbcd5e2d8a4f9fae38f done
2025-01-23T22:10:14.5339420Z #6 extracting sha256:861950bce9fa55e0462bb22503f61d8e7396f292af10969506b51e7bdb701d60
2025-01-23T22:10:14.5342397Z #6 sha256:37668a5f66677f8b8cb5499d1ffac16fdd79e5fd6647e69c8814c9f473a93119 581B / 581B done
2025-01-23T22:10:14.5345301Z #6 sha256:861950bce9fa55e0462bb22503f61d8e7396f292af10969506b51e7bdb701d60 3.42MB / 3.42MB 0.1s done
2025-01-23T22:10:14.5347683Z #6 sha256:6380aa6b04faa579332d4c9d1f65bd7093012ba6e01d9bbcd5e2d8a4f9fae38f 8.08kB / 8.08kB done
2025-01-23T22:10:14.5349916Z #6 sha256:078600ccbb944bc762a06627798691a55d539185aeb9c2c33824421a5b47bf9f 1.02kB / 1.02kB done
2025-01-23T22:10:14.7639599Z #6 extracting sha256:861950bce9fa55e0462bb22503f61d8e7396f292af10969506b51e7bdb701d60 0.1s done
2025-01-23T22:10:14.7641280Z #6 DONE 0.2s
2025-01-23T22:10:14.7641686Z 
2025-01-23T22:10:14.7642361Z #7 [2/6] RUN apk --no-cache add git bash
2025-01-23T22:10:14.7643873Z #7 0.142 fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
2025-01-23T22:10:14.9969172Z #7 0.224 fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
2025-01-23T22:10:15.0702236Z #7 0.448 (1/15) Installing ncurses-terminfo-base (6.4_p20231125-r0)
2025-01-23T22:10:15.1709707Z #7 0.455 (2/15) Installing libncursesw (6.4_p20231125-r0)
2025-01-23T22:10:15.1710849Z #7 0.463 (3/15) Installing readline (8.2.1-r2)
2025-01-23T22:10:15.1711213Z #7 0.468 (4/15) Installing bash (5.2.21-r0)
2025-01-23T22:10:15.1711560Z #7 0.485 Executing bash-5.2.21-r0.post-install
2025-01-23T22:10:15.1711933Z #7 0.487 (5/15) Installing ca-certificates (20241121-r1)
2025-01-23T22:10:15.1712591Z #7 0.512 (6/15) Installing brotli-libs (1.1.0-r1)
2025-01-23T22:10:15.1712942Z #7 0.522 (7/15) Installing c-ares (1.27.0-r0)
2025-01-23T22:10:15.1713265Z #7 0.526 (8/15) Installing libunistring (1.1-r2)
2025-01-23T22:10:15.1713586Z #7 0.539 (9/15) Installing libidn2 (2.3.4-r4)
2025-01-23T22:10:15.1713912Z #7 0.544 (10/15) Installing nghttp2-libs (1.58.0-r0)
2025-01-23T22:10:15.1714239Z #7 0.549 (11/15) Installing libpsl (0.21.5-r0)
2025-01-23T22:10:15.3005414Z #7 0.553 (12/15) Installing libcurl (8.11.1-r0)
2025-01-23T22:10:15.3005989Z #7 0.560 (13/15) Installing libexpat (2.6.4-r0)
2025-01-23T22:10:15.3006422Z #7 0.564 (14/15) Installing pcre2 (10.42-r2)
2025-01-23T22:10:15.3007083Z #7 0.572 (15/15) Installing git (2.43.6-r0)
2025-01-23T22:10:15.3007494Z #7 0.631 Executing busybox-1.36.1-r19.trigger
2025-01-23T22:10:15.3007841Z #7 0.636 Executing ca-certificates-20241121-r1.trigger
2025-01-23T22:10:15.3008182Z #7 0.679 OK: 21 MiB in 30 packages
2025-01-23T22:10:15.4112779Z #7 DONE 0.8s
2025-01-23T22:10:15.5619195Z 
2025-01-23T22:10:15.5619954Z #8 [3/6] RUN rm -rf /var/lib/apt/lists/*
2025-01-23T22:10:15.5812707Z #8 DONE 0.2s
2025-01-23T22:10:15.7320479Z 
2025-01-23T22:10:15.7320923Z #9 [4/6] RUN  apk update
2025-01-23T22:10:15.7378228Z #9 0.156 fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
2025-01-23T22:10:15.8379999Z #9 0.257 fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
2025-01-23T22:10:16.0879964Z #9 0.507 v3.19.6-24-g0a8cf7493bc [https://dl-cdn.alpinelinux.org/alpine/v3.19/main]
2025-01-23T22:10:16.0880918Z #9 0.507 v3.19.6-24-g0a8cf7493bc [https://dl-cdn.alpinelinux.org/alpine/v3.19/community]
2025-01-23T22:10:16.0881681Z #9 0.507 OK: 23034 distinct packages available
2025-01-23T22:10:16.3115415Z #9 DONE 0.6s
2025-01-23T22:10:16.3115669Z 
2025-01-23T22:10:16.3115912Z #10 [5/6] RUN apk add git
2025-01-23T22:10:16.5448475Z #10 0.384 OK: 21 MiB in 30 packages
2025-01-23T22:10:16.7658305Z #10 DONE 0.4s
2025-01-23T22:10:16.7658623Z 
2025-01-23T22:10:16.7658791Z #11 [6/6] COPY entrypoint.sh /entrypoint.sh
2025-01-23T22:10:16.7659226Z #11 DONE 0.0s
2025-01-23T22:10:16.7659451Z 
2025-01-23T22:10:16.7659578Z #12 exporting to image
2025-01-23T22:10:16.7659902Z #12 exporting layers
2025-01-23T22:10:17.0274629Z #12 exporting layers 0.4s done
2025-01-23T22:10:17.0548289Z #12 writing image sha256:7bfcb3ddd1b86be264899613aee44a967274fe0cfc4005aab1aa3326ecbfec97 done
2025-01-23T22:10:17.0550850Z #12 naming to docker.io/library/88fc44:57da35312ff946c2a167c21830a41d1c done
2025-01-23T22:10:17.0551433Z #12 DONE 0.4s
2025-01-23T22:10:17.0608819Z ##[endgroup]
2025-01-23T22:10:17.0856142Z ##[group]Run actions/checkout@v4
2025-01-23T22:10:17.0856683Z with:
2025-01-23T22:10:17.0856858Z   fetch-depth: 0
2025-01-23T22:10:17.0857066Z   submodules: true
2025-01-23T22:10:17.0857282Z   repository: fulcrumgenomics/pybwa
2025-01-23T22:10:17.0857654Z   token: ***
2025-01-23T22:10:17.0857829Z   ssh-strict: true
2025-01-23T22:10:17.0858009Z   ssh-user: git
2025-01-23T22:10:17.0858189Z   persist-credentials: true
2025-01-23T22:10:17.0858426Z   clean: true
2025-01-23T22:10:17.0858667Z   sparse-checkout-cone-mode: true
2025-01-23T22:10:17.0858889Z   fetch-tags: false
2025-01-23T22:10:17.0859070Z   show-progress: true
2025-01-23T22:10:17.0859258Z   lfs: false
2025-01-23T22:10:17.0859423Z   set-safe-directory: true
2025-01-23T22:10:17.0859823Z env:
2025-01-23T22:10:17.0860000Z   POETRY_VERSION: 1.8.2
2025-01-23T22:10:17.0860194Z ##[endgroup]
2025-01-23T22:10:17.2872578Z Syncing repository: fulcrumgenomics/pybwa
2025-01-23T22:10:17.2873909Z ##[group]Getting Git version info
2025-01-23T22:10:17.2874346Z Working directory is '/home/runner/work/pybwa/pybwa'
2025-01-23T22:10:17.2874856Z [command]/usr/bin/git version
2025-01-23T22:10:17.2886470Z git version 2.48.1
2025-01-23T22:10:17.2914530Z ##[endgroup]
2025-01-23T22:10:17.2937440Z Temporarily overriding HOME='/home/runner/work/_temp/942d0a37-321e-4257-b151-94c73270fb63' before making global git config changes
2025-01-23T22:10:17.2938776Z Adding repository directory to the temporary git global config as a safe directory
2025-01-23T22:10:17.2944121Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/pybwa/pybwa
2025-01-23T22:10:17.2979238Z Deleting the contents of '/home/runner/work/pybwa/pybwa'
2025-01-23T22:10:17.2983481Z ##[group]Initializing the repository
2025-01-23T22:10:17.2987844Z [command]/usr/bin/git init /home/runner/work/pybwa/pybwa
2025-01-23T22:10:17.3079240Z hint: Using 'master' as the name for the initial branch. This default branch name
2025-01-23T22:10:17.3080213Z hint: is subject to change. To configure the initial branch name to use in all
2025-01-23T22:10:17.3080983Z hint: of your new repositories, which will suppress this warning, call:
2025-01-23T22:10:17.3081527Z hint:
2025-01-23T22:10:17.3081924Z hint: 	git config --global init.defaultBranch <name>
2025-01-23T22:10:17.3082484Z hint:
2025-01-23T22:10:17.3082773Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2025-01-23T22:10:17.3083232Z hint: 'development'. The just-created branch can be renamed via this command:
2025-01-23T22:10:17.3083693Z hint:
2025-01-23T22:10:17.3083878Z hint: 	git branch -m <name>
2025-01-23T22:10:17.3086765Z Initialized empty Git repository in /home/runner/work/pybwa/pybwa/.git/
2025-01-23T22:10:17.3098175Z [command]/usr/bin/git remote add origin https://github.com/fulcrumgenomics/pybwa
2025-01-23T22:10:17.3133454Z ##[endgroup]
2025-01-23T22:10:17.3134036Z ##[group]Disabling automatic garbage collection
2025-01-23T22:10:17.3137767Z [command]/usr/bin/git config --local gc.auto 0
2025-01-23T22:10:17.3165980Z ##[endgroup]
2025-01-23T22:10:17.3166511Z ##[group]Setting up auth
2025-01-23T22:10:17.3172827Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2025-01-23T22:10:17.3201391Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2025-01-23T22:10:17.3504828Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2025-01-23T22:10:17.3533668Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2025-01-23T22:10:17.3756253Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
2025-01-23T22:10:17.3795257Z ##[endgroup]
2025-01-23T22:10:17.3795749Z ##[group]Fetching the repository
2025-01-23T22:10:17.3804397Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
2025-01-23T22:10:17.8861919Z From https://github.com/fulcrumgenomics/pybwa
2025-01-23T22:10:17.8863194Z  * [new branch]      main       -> origin/main
2025-01-23T22:10:17.8864244Z  * [new tag]         0.0.1      -> 0.0.1
2025-01-23T22:10:17.8864796Z  * [new tag]         1.0.0      -> 1.0.0
2025-01-23T22:10:17.8865249Z  * [new tag]         1.0.1      -> 1.0.1
2025-01-23T22:10:17.8866329Z  * [new tag]         1.0.2      -> 1.0.2
2025-01-23T22:10:17.8867097Z  * [new tag]         1.0.3      -> 1.0.3
2025-01-23T22:10:17.8869375Z  * [new tag]         1.0.4      -> 1.0.4
2025-01-23T22:10:17.8870121Z  * [new tag]         1.1.0      -> 1.1.0
2025-01-23T22:10:17.8871709Z  * [new tag]         1.1.1      -> 1.1.1
2025-01-23T22:10:17.8872733Z  * [new tag]         1.1.2      -> 1.1.2
2025-01-23T22:10:17.8874416Z  * [new tag]         1.1.3      -> 1.1.3
2025-01-23T22:10:17.8876536Z  * [new tag]         1.2.0      -> 1.2.0
2025-01-23T22:10:17.8877596Z  * [new tag]         1.3.0      -> 1.3.0
2025-01-23T22:10:17.8879878Z  * [new tag]         1.3.1      -> 1.3.1
2025-01-23T22:10:17.8881583Z  * [new tag]         1.3.2      -> 1.3.2
2025-01-23T22:10:17.8882614Z  * [new tag]         1.3.3      -> 1.3.3
2025-01-23T22:10:17.8883650Z  * [new tag]         1.3.4      -> 1.3.4
2025-01-23T22:10:17.8884067Z  * [new tag]         1.4.0      -> 1.4.0
2025-01-23T22:10:17.8885057Z  * [new tag]         1.4.1      -> 1.4.1
2025-01-23T22:10:17.8886043Z  * [new tag]         1.4.2      -> 1.4.2
2025-01-23T22:10:17.8928518Z [command]/usr/bin/git tag --list 1.4.2
2025-01-23T22:10:17.8956213Z 1.4.2
2025-01-23T22:10:17.8966804Z [command]/usr/bin/git rev-parse refs/tags/1.4.2
2025-01-23T22:10:17.8987688Z 0b363ccd89321022be0c2bde994d34629a2ce604
2025-01-23T22:10:17.8993337Z ##[endgroup]
2025-01-23T22:10:17.8993727Z ##[group]Determining the checkout info
2025-01-23T22:10:17.8995346Z ##[endgroup]
2025-01-23T22:10:17.9000989Z [command]/usr/bin/git sparse-checkout disable
2025-01-23T22:10:17.9042558Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
2025-01-23T22:10:17.9071037Z ##[group]Checking out the ref
2025-01-23T22:10:17.9077221Z [command]/usr/bin/git checkout --progress --force refs/tags/1.4.2
2025-01-23T22:10:17.9623234Z Note: switching to 'refs/tags/1.4.2'.
2025-01-23T22:10:17.9624844Z 
2025-01-23T22:10:17.9625582Z You are in 'detached HEAD' state. You can look around, make experimental
2025-01-23T22:10:17.9626334Z changes and commit them, and you can discard any commits you make in this
2025-01-23T22:10:17.9627050Z state without impacting any branches by switching back to a branch.
2025-01-23T22:10:17.9627479Z 
2025-01-23T22:10:17.9627760Z If you want to create a new branch to retain commits you create, you may
2025-01-23T22:10:17.9628417Z do so (now or later) by using -c with the switch command. Example:
2025-01-23T22:10:17.9628782Z 
2025-01-23T22:10:17.9628966Z   git switch -c <new-branch-name>
2025-01-23T22:10:17.9629252Z 
2025-01-23T22:10:17.9629393Z Or undo this operation with:
2025-01-23T22:10:17.9629630Z 
2025-01-23T22:10:17.9629756Z   git switch -
2025-01-23T22:10:17.9629929Z 
2025-01-23T22:10:17.9630234Z Turn off this advice by setting config variable advice.detachedHead to false
2025-01-23T22:10:17.9630624Z 
2025-01-23T22:10:17.9630759Z HEAD is now at 0b363cc chore(release): bump to 1.4.2 (#45)
2025-01-23T22:10:17.9637427Z ##[endgroup]
2025-01-23T22:10:17.9637792Z ##[group]Setting up auth for fetching submodules
2025-01-23T22:10:17.9646240Z [command]/usr/bin/git config --global http.https://github.com/.extraheader AUTHORIZATION: basic ***
2025-01-23T22:10:17.9688498Z [command]/usr/bin/git config --global --unset-all url.https://github.com/.insteadOf
2025-01-23T22:10:17.9719850Z [command]/usr/bin/git config --global --add url.https://github.com/.insteadOf git@github.com:
2025-01-23T22:10:17.9750198Z [command]/usr/bin/git config --global --add url.https://github.com/.insteadOf org-13546013@github.com:
2025-01-23T22:10:17.9778044Z ##[endgroup]
2025-01-23T22:10:17.9778617Z ##[group]Fetching submodules
2025-01-23T22:10:17.9782749Z [command]/usr/bin/git submodule sync
2025-01-23T22:10:18.0012737Z [command]/usr/bin/git -c protocol.version=2 submodule update --init --force
2025-01-23T22:10:18.0249055Z Submodule 'bwa' (https://github.com/lh3/bwa.git) registered for path 'bwa'
2025-01-23T22:10:18.0274769Z Cloning into '/home/runner/work/pybwa/pybwa/bwa'...
2025-01-23T22:10:18.5577024Z Submodule path 'bwa': checked out '79b230de48c74156f9d3c26795a360fc5a2d5d3b'
2025-01-23T22:10:18.5588869Z [command]/usr/bin/git submodule foreach git config --local gc.auto 0
2025-01-23T22:10:18.5800059Z Entering 'bwa'
2025-01-23T22:10:18.5830188Z ##[endgroup]
2025-01-23T22:10:18.5830655Z ##[group]Persisting credentials for submodules
2025-01-23T22:10:18.5838670Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'url\.https\:\/\/github\.com\/\.insteadOf' && git config --local --unset-all 'url.https://github.com/.insteadOf' || :"
2025-01-23T22:10:18.6050687Z Entering 'bwa'
2025-01-23T22:10:18.6105826Z [command]/usr/bin/git submodule foreach sh -c "git config --local 'http.https://github.com/.extraheader' 'AUTHORIZATION: basic ***' && git config --local --show-origin --name-only --get-regexp remote.origin.url"
2025-01-23T22:10:18.6316038Z Entering 'bwa'
2025-01-23T22:10:18.6353861Z file:/home/runner/work/pybwa/pybwa/.git/modules/bwa/config	remote.origin.url
2025-01-23T22:10:18.6376908Z [command]/usr/bin/git submodule foreach git config --local --add 'url.https://github.com/.insteadOf' 'git@github.com:'
2025-01-23T22:10:18.6588560Z Entering 'bwa'
2025-01-23T22:10:18.6622551Z [command]/usr/bin/git submodule foreach git config --local --add 'url.https://github.com/.insteadOf' 'org-13546013@github.com:'
2025-01-23T22:10:18.6831944Z Entering 'bwa'
2025-01-23T22:10:18.6862377Z ##[endgroup]
2025-01-23T22:10:18.6898893Z [command]/usr/bin/git log -1 --format=%H
2025-01-23T22:10:18.6923295Z 0b363ccd89321022be0c2bde994d34629a2ce604
2025-01-23T22:10:18.7099553Z ##[group]Run rickstaa/action-contains-tag@v1
2025-01-23T22:10:18.7099845Z with:
2025-01-23T22:10:18.7100018Z   reference: main
2025-01-23T22:10:18.7100186Z   tag: 1.4.2
2025-01-23T22:10:18.7100343Z   verbose: true
2025-01-23T22:10:18.7100507Z   frail: true
2025-01-23T22:10:18.7100656Z env:
2025-01-23T22:10:18.7100812Z   POETRY_VERSION: 1.8.2
2025-01-23T22:10:18.7100999Z ##[endgroup]
2025-01-23T22:10:18.7185958Z ##[command]/usr/bin/docker run --name fc4457da35312ff946c2a167c21830a41d1c_829f24 --label 88fc44 --workdir /github/workspace --rm -e "POETRY_VERSION" -e "INPUT_REFERENCE" -e "INPUT_TAG" -e "INPUT_VERBOSE" -e "INPUT_FRAIL" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/pybwa/pybwa":"/github/workspace" 88fc44:57da35312ff946c2a167c21830a41d1c
2025-01-23T22:10:18.9649064Z [action-contains-tag] Branch 'remotes/origin/HEAD -> origin/main' does not contain tag '1.4.2'.
2025-01-23T22:10:19.0588738Z Post job cleanup.
2025-01-23T22:10:19.1528052Z [command]/usr/bin/git version
2025-01-23T22:10:19.1564751Z git version 2.48.1
2025-01-23T22:10:19.1608645Z Temporarily overriding HOME='/home/runner/work/_temp/b62dce3a-235a-4a6c-8dbf-523bb186bbbf' before making global git config changes
2025-01-23T22:10:19.1609880Z Adding repository directory to the temporary git global config as a safe directory
2025-01-23T22:10:19.1615235Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/pybwa/pybwa
2025-01-23T22:10:19.1656251Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2025-01-23T22:10:19.1688563Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2025-01-23T22:10:19.1902740Z Entering 'bwa'
2025-01-23T22:10:19.1960930Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2025-01-23T22:10:19.1981390Z http.https://github.com/.extraheader
2025-01-23T22:10:19.1994474Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
2025-01-23T22:10:19.2025285Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2025-01-23T22:10:19.2237685Z Entering 'bwa'
2025-01-23T22:10:19.2261397Z http.https://github.com/.extraheader
2025-01-23T22:10:19.2409274Z Evaluate and set job outputs
2025-01-23T22:10:19.2414513Z Set output 'on_main'
2025-01-23T22:10:19.2416323Z Cleaning up orphan processes
```

</details>